### PR TITLE
Send the initial boundary line before the first part in the response

### DIFF
--- a/src/esp32cam/asyncweb.cpp
+++ b/src/esp32cam/asyncweb.cpp
@@ -192,7 +192,8 @@ MjpegResponse::sendPart(uint8_t* buf, size_t buflen) {
   if (m_sendRemain == 0) {
     switch (m_sendNext) {
       case SIPartHeader:
-        m_hdr.preparePartHeader(m_ctrl.getFrame()->size());
+        m_hdr.preparePartHeader(m_ctrl.getFrame()->size(), !isInitialBoundarySent);
+        isInitialBoundarySent = true;
         m_sendBuf = reinterpret_cast<const uint8_t*>(m_hdr.buf);
         m_sendRemain = m_hdr.size;
         m_sendNext = SIFrame;

--- a/src/esp32cam/asyncweb.hpp
+++ b/src/esp32cam/asyncweb.hpp
@@ -104,6 +104,8 @@ public:
 private:
   size_t sendPart(uint8_t* buf, size_t buflen);
 
+  bool isInitialBoundarySent = false;
+
 private:
   detail::CaptureTask m_task;
   using Ctrl = detail::MjpegController;

--- a/src/esp32cam/mjpeg.cpp
+++ b/src/esp32cam/mjpeg.cpp
@@ -77,8 +77,9 @@ MjpegHeader::prepareResponseContentType() {
 }
 
 void
-MjpegHeader::preparePartHeader(size_t contentLength) {
-  size = snprintf(buf, sizeof(buf),
+MjpegHeader::preparePartHeader(size_t contentLength, bool includeInitialBoundary) {
+  size = includeInitialBoundary ? snprintf(buf, sizeof(buf), "--" BOUNDARY "\r\n") : 0;
+  size += snprintf(buf + size, sizeof(buf) - size,
                   "Content-Type: image/jpeg\r\n"
                   "Content-Length: %zu\r\n"
                   "\r\n",

--- a/src/esp32cam/mjpeg.hpp
+++ b/src/esp32cam/mjpeg.hpp
@@ -108,7 +108,7 @@ public:
 
   void prepareResponseContentType();
 
-  void preparePartHeader(size_t contentLength);
+  void preparePartHeader(size_t contentLength, bool includeInitialBoundary = false);
 
   void preparePartTrailer();
 


### PR DESCRIPTION
(to conform with the RFC and appease ffmpeg)

refs #67