### PR TITLE
Exposed the camera clock setting

### DIFF
--- a/examples/AsyncCam/handlers.cpp
+++ b/examples/AsyncCam/handlers.cpp
@@ -18,6 +18,7 @@ static const char FRONTPAGE[] = R"EOT(
 %vflip%
 %rawGma%
 %lensCorrection%
+%xclk%
 <input type="submit" value="update">
 </p></form>
 <p id="controls">
@@ -138,6 +139,7 @@ rewriteFrontpage(const esp32cam::Settings& s, const String& var) {
   SHOW_INT(brightness, -2, 2)
   SHOW_INT(contrast, -2, 2)
   SHOW_INT(saturation, -2, 2)
+  SHOW_INT(xclk, 6, 24)
   SHOW_BOOL(hmirror)
   SHOW_BOOL(vflip)
   SHOW_BOOL(rawGma)
@@ -166,6 +168,7 @@ handleUpdate(AsyncWebServerRequest* req) {
     SAVE_INT(gain);
     SAVE_INT(lightMode);
     SAVE_INT(specialEffect);
+	SAVE_INT(xclk);
     SAVE_BOOL(hmirror);
     SAVE_BOOL(vflip);
     SAVE_BOOL(rawGma);

--- a/src/esp32cam/config.cpp
+++ b/src/esp32cam/config.cpp
@@ -112,6 +112,7 @@ CameraClass::status() const {
   result.vflip = ss.vflip != 0;
   result.rawGma = ss.raw_gma != 0;
   result.lensCorrection = ss.lenc != 0;
+  result.xclk = sensor->xclk_freq_hz / 1000000U;
   return result;
 }
 
@@ -155,6 +156,7 @@ CameraClass::update(const Settings& settings, int sleepFor) {
   CHECK_RANGE(lightMode, -1, 4);
   CHECK_RANGE(specialEffect, 0, 6);
   CHECK_RANGE(gain, -128, 31);
+  CHECK_RANGE(xclk, 6, 24);
 
   UPDATE3(framesize, settings.resolution.as<framesize_t>(), framesize_t);
   UPDATE1(brightness);
@@ -182,6 +184,16 @@ CameraClass::update(const Settings& settings, int sleepFor) {
   } else {
     UPDATE2(awb_gain, 1);
     UPDATE2(wb_mode, settings.lightMode);
+  }
+
+  int prev = sensor->xclk_freq_hz / 1000000U, desired = settings.xclk;
+  if (prev != desired) {
+    int res = sensor->set_xclk(sensor, LEDC_TIMER_0, desired);
+    ESP32CAM_LOG("update xclk %d => %d %s", prev, desired,
+                 res == 0 ? "success" : "failure");
+    if (res != 0) {
+      return false;
+    }
   }
 
 #undef CHECK_RANGE

--- a/src/esp32cam/config.hpp
+++ b/src/esp32cam/config.hpp
@@ -94,6 +94,9 @@ struct Settings {
    * - AGC enabled: -2,-4,-8,-16,-32,-64,-128, which corresponds to 2x ~ 128x gain.
    */
   int8_t gain;
+  
+  /** @brief Camera clock value in MHz. Recommended to be between 6 and 24. */
+  int8_t xclk;
 
   /** @brief Image light mode. */
   LightMode lightMode;


### PR DESCRIPTION
It seems that lowering the clock speed to 10MHz for example will make the image brighter (like increasing the gain twice but with noticeably less noise). I'd guess it is not just the brightness that the clock may influence so should be good to have this option available.

Cheers